### PR TITLE
Fix superfluous response.WriteHeader call

### DIFF
--- a/src/api/main.go
+++ b/src/api/main.go
@@ -114,7 +114,6 @@ func getLatest(w http.ResponseWriter, r *http.Request) {
 	}{latest})
 
 	w.Write(resp)
-	w.WriteHeader(200)
 }
 
 func register(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Fix superfluous response.WriteHeader call from main.getLatest
